### PR TITLE
fix(ingest): match emulator project ID 'spof-io'

### DIFF
--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -11,7 +11,7 @@ let db;
 
 if (emulatorHost) {
     console.log(`⚠️ FIRESTORE_EMULATOR_HOST detected (${emulatorHost}). Connecting to Emulator...`);
-    initializeApp({ projectId: "skahl-stats" });
+    initializeApp({ projectId: "spof-io" });
     db = getFirestore();
 } else if (serviceAccountEnv) {
     initializeApp({ credential: cert(JSON.parse(serviceAccountEnv)) });


### PR DESCRIPTION
Updates local ingestion script to use 'spof-io' projectId when connecting to emulator, matching .firebaserc default.