### PR TITLE
Fix: Set VITE_COLLECTION_PREFIX for deployments

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Build Web App
         run: cd web && npm run build
         env:
+          VITE_COLLECTION_PREFIX: 'skahl'
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build Web App
         run: cd web && npm run build
         env:
+          VITE_COLLECTION_PREFIX: 'skahl'
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
Ensures the build process uses the correct 'skahl' prefix for Firestore collections, preventing the use of default/fallback data.