### PR TITLE
fix: add missing composite index for game details query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2,20 +2,6 @@
     "indexes": [
         {
             "collectionGroup": "skahl_games",
-            "queryScope": "COLLECTION_GROUP",
-            "fields": [
-                {
-                    "fieldPath": "has_details",
-                    "order": "ASCENDING"
-                },
-                {
-                    "fieldPath": "starts_at",
-                    "order": "ASCENDING"
-                }
-            ]
-        },
-        {
-            "collectionGroup": "skahl_games",
             "queryScope": "COLLECTION",
             "fields": [
                 {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,20 @@
                     "order": "ASCENDING"
                 }
             ]
+        },
+        {
+            "collectionGroup": "skahl_games",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "has_details",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "starts_at",
+                    "order": "ASCENDING"
+                }
+            ]
         }
     ],
     "fieldOverrides": []


### PR DESCRIPTION
The Daily Data Ingest workflow was failing because the query in `ingest_game_details.ts` requires a composite index on `has_details` and `starts_at` with COLLECTION scope.

**Issue:**
```
FAILED_PRECONDITION: The query requires an index
```

**Fix:**
Added the missing index to `firestore.indexes.json`. The index has already been deployed to Firebase.

**Testing:**
The next scheduled run of the Daily Data Ingest workflow should succeed.